### PR TITLE
Revamp dashboard experience and add news feed

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import LobbyDetailPage from './pages/LobbyDetailPage.jsx';
 import MatchmakingPage from './pages/MatchmakingPage.jsx';
 import ChatPage from './pages/ChatPage.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
+import NewsFeedPage from './pages/NewsFeedPage.jsx';
 import DashboardLayout from './components/DashboardLayout.jsx';
 import SplashScreen from './components/SplashScreen.jsx';
 
@@ -50,6 +51,7 @@ const App = () => {
         }
       >
         <Route index element={<HomePage />} />
+        <Route path="news" element={<NewsFeedPage />} />
         <Route path="lobbies" element={<LobbiesPage />} />
         <Route path="lobbies/:lobbyId" element={<LobbyDetailPage />} />
         <Route path="matchmaking" element={<MatchmakingPage />} />

--- a/frontend/src/assets/games/among-us.svg
+++ b/frontend/src/assets/games/among-us.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="among-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff416c" />
+      <stop offset="100%" stop-color="#ff4b2b" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#among-gradient)" />
+  <g fill="#ffffff" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="58" x="120" y="98">AMONG</text>
+    <text font-size="58" x="120" y="168">US</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/apex-legends.svg
+++ b/frontend/src/assets/games/apex-legends.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="apex-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#cb356b" />
+      <stop offset="100%" stop-color="#bd3f32" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#apex-gradient)" />
+  <g fill="#ffffff" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="62" x="120" y="132">APEX</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/baldurs-gate-3.svg
+++ b/frontend/src/assets/games/baldurs-gate-3.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg3-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f1c2c" />
+      <stop offset="100%" stop-color="#928dab" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#bg3-gradient)" />
+  <g fill="#f2e8cf" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="64" x="120" y="132">BG3</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/borderlands-2.svg
+++ b/frontend/src/assets/games/borderlands-2.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bl2-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f7971e" />
+      <stop offset="100%" stop-color="#ffd200" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#bl2-gradient)" />
+  <g fill="#2d1e0f" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="64" x="120" y="132">BL2</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/dead-by-daylight.svg
+++ b/frontend/src/assets/games/dead-by-daylight.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="dbd-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29" />
+      <stop offset="50%" stop-color="#302b63" />
+      <stop offset="100%" stop-color="#24243e" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#dbd-gradient)" />
+  <g fill="#d8e6ff" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="62" x="120" y="132">DBD</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/default-game.svg
+++ b/frontend/src/assets/games/default-game.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-default" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3f2b96" />
+      <stop offset="100%" stop-color="#a8c0ff" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#grad-default)" />
+  <g fill="#ffffff" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="72" x="120" y="132">🎮</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/diablo.svg
+++ b/frontend/src/assets/games/diablo.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="diablo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8e0e00" />
+      <stop offset="100%" stop-color="#1f1c18" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#diablo-gradient)" />
+  <g fill="#ffdd8e" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="60" x="120" y="132">D IV</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/it-takes-two.svg
+++ b/frontend/src/assets/games/it-takes-two.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="itt-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f7971e" />
+      <stop offset="100%" stop-color="#ffd200" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#itt-gradient)" />
+  <g fill="#5e2a0c" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="58" x="120" y="112">IT</text>
+    <text font-size="58" x="120" y="172">TWO</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/league-of-legends.svg
+++ b/frontend/src/assets/games/league-of-legends.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="lol-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f2027" />
+      <stop offset="50%" stop-color="#203a43" />
+      <stop offset="100%" stop-color="#2c5364" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#lol-gradient)" />
+  <g fill="#f9d36c" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="64" x="120" y="128">LoL</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/minecraft.svg
+++ b/frontend/src/assets/games/minecraft.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="mc-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#56ab2f" />
+      <stop offset="100%" stop-color="#a8e063" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#mc-gradient)" />
+  <g fill="#2f2519" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="62" x="120" y="132">MC</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/pokemon.svg
+++ b/frontend/src/assets/games/pokemon.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="poke-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00c6ff" />
+      <stop offset="100%" stop-color="#0072ff" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#poke-gradient)" />
+  <g fill="#ffeb3b" stroke="#1a237e" stroke-width="4" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="56" x="120" y="132">PKMN</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/tetris.svg
+++ b/frontend/src/assets/games/tetris.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="tetris-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff512f" />
+      <stop offset="100%" stop-color="#dd2476" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#tetris-gradient)" />
+  <g fill="#fff" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="58" x="120" y="98">TET</text>
+    <text font-size="58" x="120" y="168">RIS</text>
+  </g>
+</svg>

--- a/frontend/src/assets/games/valorant.svg
+++ b/frontend/src/assets/games/valorant.svg
@@ -1,0 +1,12 @@
+<svg width="240" height="240" viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="val-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff0844" />
+      <stop offset="100%" stop-color="#ffb199" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="36" fill="url(#val-gradient)" />
+  <g fill="#0b1f2a" font-family="Poppins, Arial" font-weight="700" text-anchor="middle">
+    <text font-size="60" x="120" y="132">VAL</text>
+  </g>
+</svg>

--- a/frontend/src/components/BottomNav.jsx
+++ b/frontend/src/components/BottomNav.jsx
@@ -4,9 +4,11 @@ import { RiTeamFill } from 'react-icons/ri';
 import { IoChatbubbleEllipses } from 'react-icons/io5';
 import { TbSwords } from 'react-icons/tb';
 import { FaUserAstronaut } from 'react-icons/fa';
+import { MdOutlineNewspaper } from 'react-icons/md';
 
 const navItems = [
-  { label: 'Discover', icon: PiCompassFill, to: '/' },
+  { label: 'Home', icon: PiCompassFill, to: '/' },
+  { label: 'News', icon: MdOutlineNewspaper, to: '/news' },
   { label: 'Lobbies', icon: RiTeamFill, to: '/lobbies' },
   { label: 'Match', icon: TbSwords, to: '/matchmaking' },
   { label: 'Chat', icon: IoChatbubbleEllipses, to: '/chat' },

--- a/frontend/src/components/DashboardLayout.jsx
+++ b/frontend/src/components/DashboardLayout.jsx
@@ -12,6 +12,7 @@ const DashboardLayout = () => {
   const displayName = user?.profile?.displayName || user?.username || 'Player';
   const subtitleMap = {
     '/': 'Connect, compete and belong',
+    '/news': 'Catch up with your crew',
     '/lobbies': 'Coordinate with your squads',
     '/matchmaking': 'Tune your vibe and find the perfect lobby',
     '/chat': 'Keep the hype going',

--- a/frontend/src/components/GameCard.jsx
+++ b/frontend/src/components/GameCard.jsx
@@ -1,17 +1,14 @@
 import clsx from 'clsx';
+import { getGameArt } from '../services/gameArt.js';
 
 const GameCard = ({ game, onSelect, isActive = false, actionSlot }) => {
-  const cover = game?.coverImage?.url || game?.coverImage?.thumbnailUrl;
+  const cover = getGameArt(game);
   const genres = (game?.genres || []).slice(0, 2).map((genre) => genre.name).join(' • ');
 
   return (
     <div className={clsx('game-card', isActive && 'game-card--active')}>
       <button type="button" className="game-card__media" onClick={onSelect}>
-        {cover ? (
-          <img src={cover} alt={game.name} loading="lazy" />
-        ) : (
-          <div className="game-card__placeholder">{game.name?.slice(0, 2)}</div>
-        )}
+        <img src={cover} alt={game.name} loading="lazy" />
       </button>
       <div className="game-card__body">
         <div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -115,12 +115,12 @@ a:hover {
   bottom: 24px;
   left: 50%;
   transform: translateX(-50%);
-  width: min(640px, calc(100% - 32px));
+  width: min(720px, calc(100% - 32px));
   background: rgba(24, 17, 47, 0.85);
   border-radius: 22px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
   padding: 12px 16px;
   gap: 12px;
   backdrop-filter: blur(24px);
@@ -760,6 +760,14 @@ a:hover {
   color: var(--text-secondary);
 }
 
+.page__notice {
+  background: rgba(124, 92, 255, 0.15);
+  border-left: 3px solid var(--primary);
+  padding: 12px 16px;
+  border-radius: 12px;
+  color: #fff;
+}
+
 .auth-shell {
   min-height: 100vh;
   display: grid;
@@ -873,5 +881,419 @@ a:hover {
   .panel__placeholder {
     width: 100%;
     height: 200px;
+  }
+}
+
+/* Modern surfaces */
+.surface {
+  background: rgba(26, 18, 52, 0.8);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 24px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.surface--hero {
+  background: linear-gradient(135deg, rgba(73, 52, 170, 0.65), rgba(255, 89, 199, 0.2));
+  backdrop-filter: blur(16px);
+}
+
+.surface--nested {
+  background: rgba(19, 12, 43, 0.85);
+}
+
+.surface__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.surface__header--stack {
+  align-items: flex-start;
+}
+
+.surface__header h2,
+.surface__header h3,
+.surface__header h4 {
+  margin: 0;
+}
+
+.surface__subtitle {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.surface__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.home-layout,
+.profile-layout,
+.news-layout {
+  display: grid;
+  gap: 24px;
+}
+
+.home-layout {
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+}
+
+.home-main,
+.profile-main,
+.news-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.home-sidebar,
+.profile-sidebar,
+.news-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.home-quick-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.session-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.session-grid strong {
+  display: block;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.session-note,
+.queue-note {
+  color: var(--text-secondary);
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.queue-summary {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.queue-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.profile-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 16px;
+}
+
+.profile-overview .label {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 4px;
+}
+
+.friend-feed,
+.lobby-spotlight,
+.news-list,
+.feed-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.friend-feed li,
+.lobby-spotlight li,
+.news-list li {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(19, 12, 43, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.friend-feed li img {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.friend-feed li strong {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+}
+
+.friend-feed li strong span {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.friend-feed li p,
+.news-list li p,
+.lobby-spotlight li p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.friend-feed .timestamp {
+  margin-left: auto;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.lobby-spotlight li {
+  justify-content: space-between;
+}
+
+.lobby-spotlight li button {
+  background: rgba(124, 92, 255, 0.2);
+  border: none;
+  color: #fff;
+  padding: 8px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.news-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+}
+
+.news-highlights article {
+  background: rgba(19, 12, 43, 0.55);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.news-highlights article strong {
+  font-size: 1.8rem;
+}
+
+.news-feed {
+  flex: 2;
+}
+
+.surface--post header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.surface--post header img {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+}
+
+.surface--post header span {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.surface--post p {
+  margin: 0;
+  color: #fff;
+}
+
+.surface--post .post-media {
+  width: 100%;
+  max-height: 280px;
+  object-fit: cover;
+  border-radius: 16px;
+}
+
+.surface--post footer {
+  display: flex;
+  gap: 16px;
+}
+
+.surface--post footer button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.profile-layout {
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+}
+
+.avatar-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 14px;
+}
+
+.avatar-option {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(19, 12, 43, 0.5);
+  color: inherit;
+  cursor: pointer;
+}
+
+.avatar-option img {
+  width: 72px;
+  height: 72px;
+  border-radius: 24px;
+}
+
+.avatar-option--active {
+  border-color: rgba(124, 92, 255, 0.6);
+  box-shadow: 0 12px 24px rgba(124, 92, 255, 0.25);
+}
+
+.game-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.linked-games {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.linked-game-card {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  background: rgba(19, 12, 43, 0.7);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 16px;
+}
+
+.linked-game-card img {
+  width: 88px;
+  height: 88px;
+  border-radius: 16px;
+  object-fit: cover;
+}
+
+.linked-game-card div {
+  display: grid;
+  gap: 10px;
+  flex: 1;
+}
+
+.feed-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.feed-form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.feed-list li {
+  background: rgba(19, 12, 43, 0.6);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.feed-list li strong {
+  display: block;
+}
+
+.feed-list li span {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.chat-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: inherit;
+  padding: 10px 16px;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+@media (max-width: 1024px) {
+  .home-layout,
+  .profile-layout,
+  .news-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .bottom-nav {
+    width: calc(100% - 32px);
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 24px 12px 96px;
+  }
+
+  .surface {
+    padding: 20px;
+  }
+
+  .surface__actions {
+    width: 100%;
+  }
+
+  .surface__actions .primary-button,
+  .surface__actions .ghost-button {
+    flex: 1;
+  }
+
+  .friend-feed li,
+  .lobby-spotlight li,
+  .news-list li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .friend-feed li .ghost-button {
+    align-self: stretch;
   }
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,11 +1,73 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import apiClient from '../services/apiClient.js';
+import dayjs from 'dayjs';
 import GameCard from '../components/GameCard.jsx';
 import StatPill from '../components/StatPill.jsx';
+import apiClient from '../services/apiClient.js';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const friendActivityMock = [
+  {
+    id: 'f1',
+    name: 'Maria',
+    handle: '@mferfly',
+    status: 'Playing Baldur\'s Gate 3 (2/4)',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Maria',
+    ago: '5m ago'
+  },
+  {
+    id: 'f2',
+    name: 'Tessa',
+    handle: '@myBad',
+    status: 'Just queued for League of Legends',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Tessa',
+    ago: '12m ago'
+  },
+  {
+    id: 'f3',
+    name: 'Cassie',
+    handle: '@glitchGoddess',
+    status: 'Streaming Valorant customs',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Cassie',
+    ago: '22m ago'
+  },
+  {
+    id: 'f4',
+    name: 'Nora',
+    handle: '@thunderNeko',
+    status: 'Looking for Apex squad',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Nora',
+    ago: '40m ago'
+  }
+];
+
+const lobbySpotlightMock = [
+  {
+    id: 'l1',
+    game: 'League of Legends',
+    title: 'Need 2 more for Aram',
+    members: '2/5',
+    language: 'English'
+  },
+  {
+    id: 'l2',
+    game: 'Minecraft',
+    title: 'Building the Empire State',
+    members: '3/20',
+    language: 'Creative'
+  },
+  {
+    id: 'l3',
+    game: 'Tetris',
+    title: 'Ranked duo grind',
+    members: '1/2',
+    language: 'Any'
+  }
+];
 
 const HomePage = () => {
   const navigate = useNavigate();
+  const { user } = useAuth();
   const [trending, setTrending] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
@@ -13,25 +75,56 @@ const HomePage = () => {
   const [loadingTrending, setLoadingTrending] = useState(false);
   const [searching, setSearching] = useState(false);
   const [error, setError] = useState(null);
+  const [queueStatus, setQueueStatus] = useState(null);
+  const [checkingStatus, setCheckingStatus] = useState(false);
+
+  const displayName = user?.profile?.displayName || user?.username || 'Commander';
+
+  const featuredSession = useMemo(
+    () => ({
+      title: 'Scheduled session',
+      // TODO: Replace with real session data once backend endpoint is ready.
+      startTime: dayjs().add(2, 'hour'),
+      game: 'League of Legends',
+      squadSize: '10/10',
+      vibe: 'Weekends only',
+      voice: 'Squad channel #aram'
+    }),
+    []
+  );
+
+  const fetchTrending = useCallback(async () => {
+    setLoadingTrending(true);
+    setError(null);
+    try {
+      const response = await apiClient.get('/games/trending', { params: { limit: 12 } });
+      const games = response.data?.data?.games || [];
+      setTrending(games);
+      setActiveGame((prev) => prev || games[0] || null);
+    } catch (err) {
+      console.error('Failed to fetch trending games', err);
+      setError('Unable to load trending games right now.');
+    } finally {
+      setLoadingTrending(false);
+    }
+  }, []);
+
+  const fetchQueueStatus = useCallback(async () => {
+    setCheckingStatus(true);
+    try {
+      const response = await apiClient.get('/matchmaking/status');
+      setQueueStatus(response.data?.data || null);
+    } catch (err) {
+      console.error('Failed to fetch matchmaking status', err);
+    } finally {
+      setCheckingStatus(false);
+    }
+  }, []);
 
   useEffect(() => {
-    const fetchTrending = async () => {
-      setLoadingTrending(true);
-      try {
-        const response = await apiClient.get('/games/trending', { params: { limit: 12 } });
-        const games = response.data?.data?.games || [];
-        setTrending(games);
-        setActiveGame((prev) => prev || games[0] || null);
-      } catch (err) {
-        console.error('Failed to fetch trending games', err);
-        setError('Unable to load trending games right now.');
-      } finally {
-        setLoadingTrending(false);
-      }
-    };
-
     fetchTrending();
-  }, []);
+    fetchQueueStatus();
+  }, [fetchQueueStatus, fetchTrending]);
 
   useEffect(() => {
     if (!searchQuery.trim()) {
@@ -64,7 +157,26 @@ const HomePage = () => {
     navigate('/matchmaking', { state: { focusGame: game } });
   };
 
-  const meta = useMemo(() => {
+  const queueSummary = useMemo(() => {
+    if (!queueStatus) {
+      return 'You are not currently queued.';
+    }
+    if (queueStatus.matchRequest === null) {
+      return queueStatus.message || 'Queue status unavailable.';
+    }
+    if (queueStatus.request) {
+      const queueInfo = queueStatus.queueInfo;
+      const mode = queueStatus.request.criteria?.gameMode || 'match';
+      const matches = queueInfo?.potentialMatches ?? 0;
+      const wait = queueInfo?.estimatedWaitTime
+        ? `${Math.round(queueInfo.estimatedWaitTime / 1000)}s`
+        : '—';
+      return `Searching ${mode} · ${matches} potential lobbies · ETA ${wait}`;
+    }
+    return 'Queue status unavailable.';
+  }, [queueStatus]);
+
+  const activeGameMeta = useMemo(() => {
     if (!activeGame) {
       return null;
     }
@@ -73,114 +185,274 @@ const HomePage = () => {
       .map((platform) => platform.abbreviation || platform.name)
       .slice(0, 4)
       .join(' • ');
+    const rating = activeGame.rating ? Math.round(activeGame.rating) : null;
 
     return {
       modes,
       platforms,
-      rating: activeGame.rating ? Math.round(activeGame.rating) : null
+      rating,
+      summary: activeGame.summary || activeGame.description || 'No summary provided yet.'
     };
   }, [activeGame]);
 
   return (
     <div className="page page--home">
-      <div className="panel panel--accent">
-        <div className="panel__content">
-          <div>
-            <h2>Search for a game</h2>
-            <p>Browse the library and jump into a lobby when you are ready.</p>
-          </div>
-          <div className="search-box">
-            <input
-              type="search"
-              placeholder="League of Legends, Valorant, It Takes Two..."
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-            />
-            <span>{searching ? 'Searching…' : '🔍'}</span>
-          </div>
-        </div>
-        {meta ? (
-          <div className="panel__meta">
-            {meta.rating ? <StatPill label="Rating" value={`${meta.rating}%`} variant="purple" /> : null}
-            {meta.modes ? <StatPill label="Modes" value={meta.modes} variant="blue" /> : null}
-            {meta.platforms ? (
-              <StatPill label="Platforms" value={meta.platforms} variant="pink" />
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-
-      {error ? <div className="page__error">{error}</div> : null}
-
-      <section className="section">
-        <div className="section__header">
-          <h3>Trending now</h3>
-          <span>{loadingTrending ? 'Loading…' : `${trending.length} games`}</span>
-        </div>
-        <div className="game-grid">
-          {trending.map((game) => (
-            <GameCard
-              key={game._id}
-              game={game}
-              onSelect={() => setActiveGame(game)}
-              isActive={activeGame?._id === game._id}
-              actionSlot={
-                <button type="button" onClick={() => handleJoinMatch(game)}>
-                  Matchmake
-                </button>
-              }
-            />
-          ))}
-        </div>
-      </section>
-
-      {searchResults.length > 0 ? (
-        <section className="section">
-          <div className="section__header">
-            <h3>Search results</h3>
-            <span>{searchResults.length} matches</span>
-          </div>
-          <div className="game-grid">
-            {searchResults.map((game) => (
-              <GameCard
-                key={game._id}
-                game={game}
-                onSelect={() => setActiveGame(game)}
-                actionSlot={
-                  <button type="button" onClick={() => handleJoinMatch(game)}>
-                    Queue up
-                  </button>
-                }
-              />
-            ))}
-          </div>
-        </section>
-      ) : null}
-
-      {activeGame ? (
-        <section className="section">
-          <div className="section__header">
-            <h3>{activeGame.name}</h3>
-            <button type="button" className="link" onClick={() => handleJoinMatch(activeGame)}>
-              Start matchmaking →
-            </button>
-          </div>
-          <div className="panel">
-            <div className="panel__content panel__content--columns">
+      <div className="home-layout">
+        <div className="home-main">
+          <section className="surface surface--hero">
+            <div className="surface__header">
               <div>
-                <p>{activeGame.summary || activeGame.description || 'No summary provided yet.'}</p>
+                <h2>Ready when you are, {displayName} ✨</h2>
+                <p>Sync your squad, jump into matchmaking or browse what\'s trending.</p>
               </div>
-              <div className="panel__artwork">
-                {activeGame.coverImage?.url ? (
-                  <img src={activeGame.coverImage.url} alt={`${activeGame.name} cover`} />
-                ) : (
-                  <div className="panel__placeholder">{activeGame.name.slice(0, 2)}</div>
-                )}
+              <div className="surface__actions">
+                <button type="button" className="primary-button" onClick={() => navigate('/matchmaking')}>
+                  Start matchmaking
+                </button>
+                <button type="button" className="ghost-button" onClick={fetchQueueStatus} disabled={checkingStatus}>
+                  {checkingStatus ? 'Refreshing…' : 'Refresh status'}
+                </button>
               </div>
             </div>
-          </div>
-        </section>
-      ) : null}
+            <div className="home-quick-stats">
+              <StatPill label="Queue" value={queueStatus?.request ? 'Active' : 'Idle'} variant="blue" />
+              <StatPill label="Shards" value={user?.virtualCurrency ?? 0} variant="pink" />
+              <StatPill label="XP" value={user?.karmaPoints ?? 0} variant="purple" />
+            </div>
+          </section>
+
+          <section className="surface surface--session">
+            <div className="surface__header">
+              <div>
+                <h3>{featuredSession.title}</h3>
+                <p className="surface__subtitle">
+                  {featuredSession.game} · Starts {featuredSession.startTime.fromNow()}
+                </p>
+              </div>
+              <button type="button" className="icon-button" onClick={() => navigate('/lobbies')}>
+                ➜
+              </button>
+            </div>
+            <div className="session-grid">
+              <div>
+                <strong>Squad</strong>
+                <p>{featuredSession.squadSize}</p>
+              </div>
+              <div>
+                <strong>Voice</strong>
+                <p>{featuredSession.voice}</p>
+              </div>
+              <div>
+                <strong>Vibe</strong>
+                <p>{featuredSession.vibe}</p>
+              </div>
+            </div>
+            <p className="session-note">
+              Waiting on 2 teammates to ready up. Share the invite or jump to the lobby page to hype them up.
+            </p>
+          </section>
+
+          <section className="surface surface--queue">
+            <div className="surface__header">
+              <div>
+                <h3>Matchmaking tracker</h3>
+                <p className="surface__subtitle">Live status of your current queue</p>
+              </div>
+              <button type="button" className="link" onClick={() => navigate('/matchmaking')}>
+                Manage queue →
+              </button>
+            </div>
+            <div className="queue-summary">{queueSummary}</div>
+            {queueStatus?.request ? (
+              <div className="queue-meta">
+                <StatPill
+                  label="Mode"
+                  value={queueStatus.request.criteria?.gameMode || '—'}
+                  variant="purple"
+                />
+                <StatPill
+                  label="Regions"
+                  value={(queueStatus.request.criteria?.regions || ['Global']).join(', ')}
+                  variant="blue"
+                />
+                <StatPill
+                  label="Players"
+                  value={`${queueStatus.request.criteria?.groupSize?.min || 1}-${
+                    queueStatus.request.criteria?.groupSize?.max || 5
+                  }`}
+                  variant="pink"
+                />
+              </div>
+            ) : null}
+            <p className="queue-note">
+              We will auto-redirect you to the lobby hub once a match is locked in.
+              {/* TODO: Trigger automatic lobby navigation when backend exposes match identifiers. */}
+            </p>
+          </section>
+
+          <section className="surface surface--library">
+            <div className="surface__header surface__header--stack">
+              <div>
+                <h3>Search for a game</h3>
+                <p className="surface__subtitle">Browse the library and jump into a lobby when you are ready.</p>
+              </div>
+              <div className="search-box">
+                <input
+                  type="search"
+                  placeholder="League of Legends, Valorant, It Takes Two…"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                />
+                <span>{searching ? 'Searching…' : '🔍'}</span>
+              </div>
+            </div>
+            {error ? <div className="page__error">{error}</div> : null}
+            <div className="surface__header">
+              <h4>Trending now</h4>
+              <span>{loadingTrending ? 'Loading…' : `${trending.length} games`}</span>
+            </div>
+            <div className="game-grid">
+              {trending.map((game) => (
+                <GameCard
+                  key={game._id}
+                  game={game}
+                  onSelect={() => setActiveGame(game)}
+                  isActive={activeGame?._id === game._id}
+                  actionSlot={
+                    <button type="button" onClick={() => handleJoinMatch(game)}>
+                      Matchmake
+                    </button>
+                  }
+                />
+              ))}
+            </div>
+            {searchResults.length > 0 ? (
+              <>
+                <div className="surface__header">
+                  <h4>Search results</h4>
+                  <span>{searchResults.length} matches</span>
+                </div>
+                <div className="game-grid">
+                  {searchResults.map((game) => (
+                    <GameCard
+                      key={game._id}
+                      game={game}
+                      onSelect={() => setActiveGame(game)}
+                      actionSlot={
+                        <button type="button" onClick={() => handleJoinMatch(game)}>
+                          Queue up
+                        </button>
+                      }
+                    />
+                  ))}
+                </div>
+              </>
+            ) : null}
+            {activeGameMeta ? (
+              <div className="surface surface--nested">
+                <div className="surface__header">
+                  <h4>{activeGame.name}</h4>
+                  <button type="button" className="link" onClick={() => handleJoinMatch(activeGame)}>
+                    Start matchmaking →
+                  </button>
+                </div>
+                <p>{activeGameMeta.summary}</p>
+                <div className="queue-meta">
+                  {activeGameMeta.rating ? (
+                    <StatPill label="Rating" value={`${activeGameMeta.rating}%`} variant="purple" />
+                  ) : null}
+                  {activeGameMeta.modes ? (
+                    <StatPill label="Modes" value={activeGameMeta.modes} variant="blue" />
+                  ) : null}
+                  {activeGameMeta.platforms ? (
+                    <StatPill label="Platforms" value={activeGameMeta.platforms} variant="pink" />
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+          </section>
+        </div>
+
+        <aside className="home-sidebar">
+          <section className="surface surface--profile">
+            <div className="surface__header">
+              <h3>Personal overview</h3>
+              <span className="surface__subtitle">Tweak matchmaking preferences in your profile</span>
+            </div>
+            <div className="profile-overview">
+              <div>
+                <span className="label">Playstyle</span>
+                <strong>{user?.gamingPreferences?.competitiveness || 'Balanced'}</strong>
+              </div>
+              <div>
+                <span className="label">Regions</span>
+                <strong>
+                  {(user?.gamingPreferences?.regions || ['Global'])
+                    .slice(0, 2)
+                    .join(', ')}
+                </strong>
+              </div>
+              <div>
+                <span className="label">Languages</span>
+                <strong>
+                  {(user?.gamingPreferences?.languages || ['English'])
+                    .slice(0, 2)
+                    .join(', ')}
+                </strong>
+              </div>
+            </div>
+            <button type="button" className="ghost-button" onClick={() => navigate('/profile')}>
+              Adjust profile
+            </button>
+          </section>
+
+          <section className="surface surface--friends">
+            <div className="surface__header">
+              <h3>Friend activity</h3>
+              <button type="button" className="link" onClick={() => navigate('/chat')}>
+                Open messages →
+              </button>
+            </div>
+            <ul className="friend-feed">
+              {friendActivityMock.map((friend) => (
+                <li key={friend.id}>
+                  <img src={friend.avatar} alt={friend.name} />
+                  <div>
+                    <strong>
+                      {friend.name}
+                      <span>{friend.handle}</span>
+                    </strong>
+                    <p>{friend.status}</p>
+                  </div>
+                  <span className="timestamp">{friend.ago}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="surface surface--lobbies">
+            <div className="surface__header">
+              <h3>Quick lobbies</h3>
+              <span className="surface__subtitle">What your community is hosting</span>
+            </div>
+            <ul className="lobby-spotlight">
+              {lobbySpotlightMock.map((lobby) => (
+                <li key={lobby.id}>
+                  <div>
+                    <strong>{lobby.title}</strong>
+                    <p>
+                      {lobby.game} · {lobby.members}
+                    </p>
+                  </div>
+                  <button type="button" onClick={() => navigate('/lobbies')}>
+                    Join
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </aside>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/NewsFeedPage.jsx
+++ b/frontend/src/pages/NewsFeedPage.jsx
@@ -1,0 +1,181 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+dayjs.extend(relativeTime);
+
+const feedMock = [
+  {
+    id: 'p1',
+    author: 'Sophia @starlitpico',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Sophia',
+    media: 'https://images.unsplash.com/photo-1578926081170-47dc463da3f0?auto=format&fit=crop&w=600&q=80',
+    content: 'OMG Gulganna is launching, so excited! #TeamRed',
+    reactions: 412,
+    comments: 68,
+    createdAt: dayjs().subtract(20, 'minute')
+  },
+  {
+    id: 'p2',
+    author: 'Tessa @myBad',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Tessa',
+    media: 'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=600&q=80',
+    content: 'Just finished custom Aram with voice commands only. Chaos & fun! 🎙️',
+    reactions: 128,
+    comments: 24,
+    createdAt: dayjs().subtract(45, 'minute')
+  },
+  {
+    id: 'p3',
+    author: 'Zoe @blaz3d',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Zoe',
+    content: 'Finally reached Emerald in League! 🟢',
+    reactions: 322,
+    comments: 45,
+    createdAt: dayjs().subtract(2, 'hour')
+  },
+  {
+    id: 'p4',
+    author: 'Billy @sketchstack',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Billy',
+    media: 'https://images.unsplash.com/photo-1611606063065-ee7946f0785b?auto=format&fit=crop&w=600&q=80',
+    content: 'New maoga fan-art drop 💜✨',
+    reactions: 89,
+    comments: 11,
+    createdAt: dayjs().subtract(4, 'hour')
+  }
+];
+
+const NewsFeedPage = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const displayName = user?.profile?.displayName || user?.username || 'Maogan';
+
+  const highlights = useMemo(
+    () => [
+      {
+        id: 'h1',
+        title: 'Friends online',
+        value: 9,
+        caption: 'Send them a ping from chat'
+      },
+      {
+        id: 'h2',
+        title: 'New achievements',
+        value: 3,
+        caption: 'Claim them before reset'
+      },
+      {
+        id: 'h3',
+        title: 'Open invites',
+        value: 4,
+        caption: 'Join a squad in seconds'
+      }
+    ],
+    []
+  );
+
+  return (
+    <div className="page page--news">
+      <section className="surface surface--hero">
+        <div className="surface__header">
+          <div>
+            <h2>Hey {displayName}, here\'s what\'s buzzing 🪩</h2>
+            <p className="surface__subtitle">Updates from your friends, favourite games and communities.</p>
+          </div>
+          <div className="surface__actions">
+            <button type="button" className="primary-button" onClick={() => navigate('/chat')}>
+              Share an update
+            </button>
+          </div>
+        </div>
+        <div className="news-highlights">
+          {highlights.map((highlight) => (
+            <article key={highlight.id}>
+              <strong>{highlight.value}</strong>
+              <span>{highlight.title}</span>
+              <p>{highlight.caption}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <div className="news-layout">
+        <aside className="news-sidebar">
+          <section className="surface surface--profile">
+            <div className="surface__header">
+              <h3>Game spotlights</h3>
+              <span className="surface__subtitle">Fresh news from the titles you follow</span>
+            </div>
+            <ul className="news-list">
+              <li>
+                <strong>League of Legends</strong>
+                <p>Patch 14.3 goes live tomorrow. Expect balance adjustments to enchanters.</p>
+              </li>
+              <li>
+                <strong>Valorant</strong>
+                <p>New agent teaser dropped. Ability reveal stream tonight at 19:00 CET.</p>
+              </li>
+              <li>
+                <strong>Baldur\'s Gate 3</strong>
+                <p>Community challenge unlocked: finish Act 2 with zero long rests. 👀</p>
+              </li>
+            </ul>
+          </section>
+
+          <section className="surface surface--friends">
+            <div className="surface__header">
+              <h3>Friend streaks</h3>
+              <span className="surface__subtitle">Keep the energy alive</span>
+            </div>
+            <ul className="news-list">
+              <li>
+                <strong>Emily &amp; Zoe</strong>
+                <p>5 days of duo queue in Apex Legends. They\'re on fire!</p>
+              </li>
+              <li>
+                <strong>Maria</strong>
+                <p>Unlocked Emerald duo streak in League of Legends.</p>
+              </li>
+              <li>
+                <strong>Pernille</strong>
+                <p>Hosting a creative Minecraft weekend build-off. RSVP open now.</p>
+              </li>
+            </ul>
+          </section>
+        </aside>
+
+        <main className="news-feed">
+          {feedMock.map((item) => (
+            <article key={item.id} className="surface surface--post">
+              <header>
+                <img src={item.avatar} alt={item.author} />
+                <div>
+                  <strong>{item.author}</strong>
+                  <span>{item.createdAt.fromNow()}</span>
+                </div>
+                <button type="button" className="icon-button" onClick={() => navigate('/profile')}>
+                  ···
+                </button>
+              </header>
+              <p>{item.content}</p>
+              {item.media ? <img src={item.media} alt="Post media" className="post-media" /> : null}
+              <footer>
+                <button type="button">❤️ {item.reactions}</button>
+                <button type="button">💬 {item.comments}</button>
+                <button type="button" className="link">
+                  Share
+                </button>
+              </footer>
+            </article>
+          ))}
+        </main>
+      </div>
+      {/* TODO: Replace mock feed with backend data once feed endpoints are available. */}
+    </div>
+  );
+};
+
+export default NewsFeedPage;

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,6 +1,67 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import apiClient from '../services/apiClient.js';
 import { useAuth } from '../context/AuthContext.jsx';
+import { getGameArt } from '../services/gameArt.js';
+
+const avatarSeeds = ['NovaFox', 'PixelMage', 'StarKnight', 'VoidSong', 'GlitchSprite', 'AuraBloom'];
+
+const socialPlatforms = [
+  { id: 'discord', label: 'Discord', placeholder: 'username#0000' },
+  { id: 'riot', label: 'Riot ID', placeholder: 'summoner#EUW' },
+  { id: 'steam', label: 'Steam', placeholder: 'steamcommunity.com/id/you' },
+  { id: 'xbox', label: 'Xbox', placeholder: 'Gamertag' },
+  { id: 'psn', label: 'PlayStation', placeholder: 'PSN ID' }
+];
+
+const friendsMock = [
+  {
+    id: 'fr1',
+    name: 'Maria',
+    handle: '@mferfly',
+    status: 'Playing Baldur\'s Gate 3',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Maria',
+    lastOnline: 'Online'
+  },
+  {
+    id: 'fr2',
+    name: 'Tessa',
+    handle: '@myBad',
+    status: 'In champion select (LoL)',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Tessa',
+    lastOnline: '5m ago'
+  },
+  {
+    id: 'fr3',
+    name: 'Cassie',
+    handle: '@glitchGoddess',
+    status: 'Streaming Valorant customs',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Cassie',
+    lastOnline: '20m ago'
+  },
+  {
+    id: 'fr4',
+    name: 'Nora',
+    handle: '@thunderNeko',
+    status: 'Looking for Apex squad',
+    avatar: 'https://api.dicebear.com/7.x/bottts/svg?seed=Nora',
+    lastOnline: 'Yesterday'
+  }
+];
+
+const defaultFeed = [
+  {
+    id: 'feed1',
+    title: 'Reached Platinum support',
+    description: 'Thanks to the squad! Time to learn jungle next.',
+    timestamp: '2h ago'
+  },
+  {
+    id: 'feed2',
+    title: 'Unlocked Riot buddy pass',
+    description: 'Invite sent to Maria. 1 more token available.',
+    timestamp: '1d ago'
+  }
+];
 
 const ProfilePage = () => {
   const { user, refreshProfile, logout } = useAuth();
@@ -9,7 +70,17 @@ const ProfilePage = () => {
   const [competitiveness, setCompetitiveness] = useState('balanced');
   const [regions, setRegions] = useState('');
   const [languages, setLanguages] = useState('');
+  const [selectedAvatar, setSelectedAvatar] = useState(avatarSeeds[0]);
+  const [socials, setSocials] = useState(() =>
+    socialPlatforms.reduce((acc, platform) => ({ ...acc, [platform.id]: '' }), {})
+  );
+  const [linkedGames, setLinkedGames] = useState([]);
+  const [newGameTitle, setNewGameTitle] = useState('');
+  const [newGameRole, setNewGameRole] = useState('');
+  const [feedEntries, setFeedEntries] = useState(defaultFeed);
+  const [feedDraft, setFeedDraft] = useState('');
   const [feedback, setFeedback] = useState(null);
+  const [localNotice, setLocalNotice] = useState(null);
   const [updating, setUpdating] = useState(false);
 
   useEffect(() => {
@@ -19,8 +90,33 @@ const ProfilePage = () => {
       setCompetitiveness(user.gamingPreferences?.competitiveness || 'balanced');
       setRegions((user.gamingPreferences?.regions || []).join(', '));
       setLanguages((user.gamingPreferences?.languages || []).join(', '));
+      if (user.profile?.avatarSeed) {
+        setSelectedAvatar(user.profile.avatarSeed);
+      }
+      if (user.socials) {
+        setSocials((prev) => ({ ...prev, ...user.socials }));
+      }
+      if (Array.isArray(user.gameProfiles) && user.gameProfiles.length > 0) {
+        setLinkedGames(
+          user.gameProfiles.map((profile) => ({
+            id: profile._id,
+            title: profile.gameId?.name || 'Game',
+            role: profile.role || profile.rank || '',
+            handle: profile.inGameName || ''
+          }))
+        );
+      }
     }
   }, [user]);
+
+  const avatarOptions = useMemo(
+    () =>
+      avatarSeeds.map((seed) => ({
+        seed,
+        url: `https://api.dicebear.com/7.x/bottts/svg?seed=${seed}`
+      })),
+    []
+  );
 
   const saveProfile = async (event) => {
     event.preventDefault();
@@ -29,7 +125,8 @@ const ProfilePage = () => {
     try {
       await apiClient.patch('/users/me', {
         displayName: displayName || undefined,
-        bio: bio || undefined
+        bio: bio || undefined,
+        avatarSeed: selectedAvatar
       });
       await refreshProfile();
       setFeedback('Profile updated successfully');
@@ -67,98 +164,321 @@ const ProfilePage = () => {
     }
   };
 
+  const handleSocialChange = (platformId, value) => {
+    setSocials((prev) => ({ ...prev, [platformId]: value }));
+  };
+
+  const handleSaveSocials = (event) => {
+    event.preventDefault();
+    setLocalNotice('Social links saved locally. TODO: persist to backend when endpoint is available.');
+  };
+
+  const handleAddGame = (event) => {
+    event.preventDefault();
+    if (!newGameTitle.trim()) {
+      return;
+    }
+    const nextGame = {
+      id: `local-${Date.now()}`,
+      title: newGameTitle,
+      role: newGameRole,
+      handle: ''
+    };
+    setLinkedGames((prev) => [nextGame, ...prev]);
+    setNewGameTitle('');
+    setNewGameRole('');
+    setLocalNotice('Game link added locally. TODO: sync with backend game profile endpoint.');
+  };
+
+  const updateGameEntry = (gameId, field, value) => {
+    setLinkedGames((prev) => prev.map((game) => (game.id === gameId ? { ...game, [field]: value } : game)));
+  };
+
+  const removeGameEntry = (gameId) => {
+    setLinkedGames((prev) => prev.filter((game) => game.id !== gameId));
+  };
+
+  const addFeedEntry = (event) => {
+    event.preventDefault();
+    if (!feedDraft.trim()) {
+      return;
+    }
+    setFeedEntries((prev) => [
+      {
+        id: `feed-${Date.now()}`,
+        title: feedDraft,
+        description: 'Shared just now',
+        timestamp: 'Just now'
+      },
+      ...prev
+    ]);
+    setFeedDraft('');
+    setLocalNotice('Posted to your personal feed locally. TODO: connect to social feed service.');
+  };
+
   if (!user) {
     return null;
   }
 
   return (
     <div className="page page--profile">
-      <section className="section">
-        <div className="section__header">
-          <h3>Your profile</h3>
-          <button type="button" className="link" onClick={logout}>
-            Log out
-          </button>
-        </div>
-        {feedback ? <div className="page__feedback">{feedback}</div> : null}
-        <form className="profile-form" onSubmit={saveProfile}>
-          <label>
-            <span>Display name</span>
-            <input
-              type="text"
-              value={displayName}
-              onChange={(event) => setDisplayName(event.target.value)}
-              placeholder="Your name"
-            />
-          </label>
-          <label>
-            <span>Bio</span>
-            <textarea
-              value={bio}
-              onChange={(event) => setBio(event.target.value)}
-              placeholder="Tell your squad about you"
-            />
-          </label>
-          <button type="submit" className="primary-button" disabled={updating}>
-            Save profile
-          </button>
-        </form>
-      </section>
-
-      <section className="section">
-        <div className="section__header">
-          <h3>Gaming preferences</h3>
-        </div>
-        <form className="profile-form" onSubmit={savePreferences}>
-          <label>
-            <span>Competitiveness</span>
-            <select value={competitiveness} onChange={(event) => setCompetitiveness(event.target.value)}>
-              <option value="casual">Casual</option>
-              <option value="balanced">Balanced</option>
-              <option value="competitive">Competitive</option>
-            </select>
-          </label>
-          <label>
-            <span>Preferred regions</span>
-            <input
-              type="text"
-              value={regions}
-              onChange={(event) => setRegions(event.target.value)}
-              placeholder="NA, EU, OC"
-            />
-          </label>
-          <label>
-            <span>Languages</span>
-            <input
-              type="text"
-              value={languages}
-              onChange={(event) => setLanguages(event.target.value)}
-              placeholder="en, es"
-            />
-          </label>
-          <button type="submit" className="primary-button" disabled={updating}>
-            Save preferences
-          </button>
-        </form>
-      </section>
-
-      <section className="section">
-        <div className="section__header">
-          <h3>Game profiles</h3>
-        </div>
-        <div className="profile-game-grid">
-          {(user.gameProfiles || []).map((profile) => (
-            <div className="profile-game-card" key={profile._id}>
-              <strong>{profile.gameId?.name || 'Game'}</strong>
-              <span>{profile.inGameName || 'IGN not set'}</span>
-              <span>{profile.rank || 'Rank not set'}</span>
+      <div className="profile-layout">
+        <div className="profile-main">
+          <section className="surface surface--hero">
+            <div className="surface__header">
+              <div>
+                <h2>Shape your vibe</h2>
+                <p className="surface__subtitle">
+                  Update your identity, connect socials and share your highlights.
+                </p>
+              </div>
+              <button type="button" className="icon-button" onClick={logout}>
+                ⇦
+              </button>
             </div>
-          ))}
-          {(!user.gameProfiles || user.gameProfiles.length === 0) && (
-            <p>No game profiles added yet. Add them via the API to see them here.</p>
-          )}
+            {feedback ? <div className="page__feedback">{feedback}</div> : null}
+            {localNotice ? <div className="page__notice">{localNotice}</div> : null}
+          </section>
+
+          <section className="surface">
+            <div className="surface__header">
+              <h3>Profile basics</h3>
+            </div>
+            <form className="profile-form" onSubmit={saveProfile}>
+              <label>
+                <span>Display name</span>
+                <input
+                  type="text"
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  placeholder="Your name"
+                />
+              </label>
+              <label>
+                <span>Bio</span>
+                <textarea
+                  value={bio}
+                  onChange={(event) => setBio(event.target.value)}
+                  placeholder="Tell your squad about you"
+                />
+              </label>
+              <div className="avatar-grid">
+                {avatarOptions.map((option) => (
+                  <button
+                    type="button"
+                    key={option.seed}
+                    className={`avatar-option ${selectedAvatar === option.seed ? 'avatar-option--active' : ''}`}
+                    onClick={() => setSelectedAvatar(option.seed)}
+                  >
+                    <img src={option.url} alt={option.seed} />
+                    <span>{option.seed}</span>
+                  </button>
+                ))}
+              </div>
+              <button type="submit" className="primary-button" disabled={updating}>
+                Save profile
+              </button>
+            </form>
+          </section>
+
+          <section className="surface">
+            <div className="surface__header">
+              <h3>Matchmaking preferences</h3>
+            </div>
+            <form className="profile-form" onSubmit={savePreferences}>
+              <label>
+                <span>Competitiveness</span>
+                <select value={competitiveness} onChange={(event) => setCompetitiveness(event.target.value)}>
+                  <option value="casual">Casual</option>
+                  <option value="balanced">Balanced</option>
+                  <option value="competitive">Competitive</option>
+                </select>
+              </label>
+              <label>
+                <span>Preferred regions</span>
+                <input
+                  type="text"
+                  value={regions}
+                  onChange={(event) => setRegions(event.target.value)}
+                  placeholder="NA, EU, OC"
+                />
+              </label>
+              <label>
+                <span>Languages</span>
+                <input
+                  type="text"
+                  value={languages}
+                  onChange={(event) => setLanguages(event.target.value)}
+                  placeholder="en, es"
+                />
+              </label>
+              <button type="submit" className="primary-button" disabled={updating}>
+                Save preferences
+              </button>
+            </form>
+          </section>
+
+          <section className="surface">
+            <div className="surface__header">
+              <h3>Linked socials</h3>
+            </div>
+            <form className="profile-form" onSubmit={handleSaveSocials}>
+              {socialPlatforms.map((platform) => (
+                <label key={platform.id}>
+                  <span>{platform.label}</span>
+                  <input
+                    type="text"
+                    value={socials[platform.id] || ''}
+                    onChange={(event) => handleSocialChange(platform.id, event.target.value)}
+                    placeholder={platform.placeholder}
+                  />
+                </label>
+              ))}
+              <button type="submit" className="ghost-button">
+                Save links
+              </button>
+            </form>
+          </section>
+
+          <section className="surface">
+            <div className="surface__header">
+              <div>
+                <h3>Game cards</h3>
+                <p className="surface__subtitle">
+                  Showcase the games you play and your roles.
+                </p>
+              </div>
+            </div>
+            <form className="game-form" onSubmit={handleAddGame}>
+              <input
+                type="text"
+                value={newGameTitle}
+                onChange={(event) => setNewGameTitle(event.target.value)}
+                placeholder="Game title"
+              />
+              <input
+                type="text"
+                value={newGameRole}
+                onChange={(event) => setNewGameRole(event.target.value)}
+                placeholder="Role, rank or preferred lane"
+              />
+              <button type="submit" className="primary-button">
+                Add game
+              </button>
+            </form>
+            <div className="linked-games">
+              {linkedGames.length === 0 ? (
+                <p className="surface__subtitle">No game cards yet. Add your main titles above.</p>
+              ) : null}
+              {linkedGames.map((game) => (
+                <article key={game.id} className="linked-game-card">
+                  <img src={getGameArt({ name: game.title })} alt={game.title} />
+                  <div>
+                    <input
+                      type="text"
+                      value={game.title}
+                      onChange={(event) => updateGameEntry(game.id, 'title', event.target.value)}
+                      placeholder="Game"
+                    />
+                    <input
+                      type="text"
+                      value={game.role}
+                      onChange={(event) => updateGameEntry(game.id, 'role', event.target.value)}
+                      placeholder="Role / rank"
+                    />
+                    <input
+                      type="text"
+                      value={game.handle}
+                      onChange={(event) => updateGameEntry(game.id, 'handle', event.target.value)}
+                      placeholder="In-game name"
+                    />
+                  </div>
+                  <button type="button" className="danger-button" onClick={() => removeGameEntry(game.id)}>
+                    Remove
+                  </button>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="surface">
+            <div className="surface__header">
+              <div>
+                <h3>Personal feed</h3>
+                <p className="surface__subtitle">Share highlights and achievements with your friends.</p>
+              </div>
+            </div>
+            <form className="feed-form" onSubmit={addFeedEntry}>
+              <textarea
+                value={feedDraft}
+                onChange={(event) => setFeedDraft(event.target.value)}
+                placeholder="Share what you\'re proud of..."
+              />
+              <button type="submit" className="primary-button">
+                Post update
+              </button>
+            </form>
+            <ul className="feed-list">
+              {feedEntries.map((entry) => (
+                <li key={entry.id}>
+                  <strong>{entry.title}</strong>
+                  <p>{entry.description}</p>
+                  <span>{entry.timestamp}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
         </div>
-      </section>
+
+        <aside className="profile-sidebar">
+          <section className="surface surface--friends">
+            <div className="surface__header">
+              <h3>Friends &amp; chat</h3>
+              <button type="button" className="link">
+                View all →
+              </button>
+            </div>
+            <ul className="friend-feed">
+              {friendsMock.map((friend) => (
+                <li key={friend.id}>
+                  <img src={friend.avatar} alt={friend.name} />
+                  <div>
+                    <strong>
+                      {friend.name}
+                      <span>{friend.handle}</span>
+                    </strong>
+                    <p>{friend.status}</p>
+                  </div>
+                  <button type="button" className="ghost-button">
+                    Chat
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="surface surface--chat">
+            <div className="surface__header">
+              <h3>Quick DM</h3>
+              <span className="surface__subtitle">Send a ping without leaving your profile.</span>
+            </div>
+            <form className="chat-form">
+              <select>
+                {friendsMock.map((friend) => (
+                  <option key={friend.id} value={friend.id}>
+                    {friend.name} ({friend.lastOnline})
+                  </option>
+                ))}
+              </select>
+              <textarea placeholder="Say hi or share a clip link" />
+              <button type="button" className="primary-button" disabled>
+                Send (coming soon)
+              </button>
+            </form>
+            {/* TODO: Wire quick DM composer to chat service when available. */}
+          </section>
+        </aside>
+      </div>
     </div>
   );
 };

--- a/frontend/src/services/gameArt.js
+++ b/frontend/src/services/gameArt.js
@@ -1,0 +1,64 @@
+import apexLegends from '../assets/games/apex-legends.svg';
+import amongUs from '../assets/games/among-us.svg';
+import baldursGate3 from '../assets/games/baldurs-gate-3.svg';
+import borderlands2 from '../assets/games/borderlands-2.svg';
+import deadByDaylight from '../assets/games/dead-by-daylight.svg';
+import defaultGame from '../assets/games/default-game.svg';
+import diablo from '../assets/games/diablo.svg';
+import itTakesTwo from '../assets/games/it-takes-two.svg';
+import leagueOfLegends from '../assets/games/league-of-legends.svg';
+import minecraft from '../assets/games/minecraft.svg';
+import pokemon from '../assets/games/pokemon.svg';
+import tetris from '../assets/games/tetris.svg';
+import valorant from '../assets/games/valorant.svg';
+
+const normaliseKey = (value = '') =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-+/g, '-');
+
+const artMap = new Map([
+  ['league-of-legends', leagueOfLegends],
+  ['lol', leagueOfLegends],
+  ['tetris', tetris],
+  ['minecraft', minecraft],
+  ['diablo', diablo],
+  ['diablo-4', diablo],
+  ['diablo-iv', diablo],
+  ['borderlands-2', borderlands2],
+  ['borderlands2', borderlands2],
+  ['among-us', amongUs],
+  ['baldurs-gate-3', baldursGate3],
+  ['baldur-s-gate-iii', baldursGate3],
+  ['it-takes-two', itTakesTwo],
+  ['apex-legends', apexLegends],
+  ['pokemon', pokemon],
+  ['pok-mon', pokemon],
+  ['dead-by-daylight', deadByDaylight],
+  ['valorant', valorant]
+]);
+
+export const getGameArt = (game = {}) => {
+  if (game.coverImage?.url || game.coverImage?.thumbnailUrl) {
+    return game.coverImage.url || game.coverImage.thumbnailUrl;
+  }
+
+  const slugKey = game.slug ? normaliseKey(game.slug) : null;
+  if (slugKey && artMap.has(slugKey)) {
+    return artMap.get(slugKey);
+  }
+
+  if (game.name) {
+    const nameKey = normaliseKey(game.name);
+    for (const [key, image] of artMap.entries()) {
+      if (nameKey.includes(key) || key.includes(nameKey)) {
+        return image;
+      }
+    }
+  }
+
+  return defaultGame;
+};
+
+export default getGameArt;


### PR DESCRIPTION
## Summary
- redesign the home dashboard with session highlights, matchmaking tracker, friend activity and an improved game library surface
- add a social news feed page and navigation entry for catching up with community updates
- expand the profile area with avatar selection, social linking, personal feed tooling and refreshed styling, plus bundled fallback game artwork

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5a58f52c88325b373e77077099dff