### PR TITLE
Enable mock lobby previews without backend

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -545,8 +545,8 @@ a:hover {
 .lobby-card__body {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  aspect-ratio: 1;
+  gap: 16px;
+  height: 100%;
 }
 
 
@@ -571,7 +571,7 @@ a:hover {
 .lobby-card__meta {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   color: var(--text-secondary);
   font-size: 0.8rem;
 }
@@ -579,6 +579,11 @@ a:hover {
 .lobby-card__join {
   width: 100%;
   margin-top: auto;
+}
+
+.lobby-card__join:hover {
+  background: #a855f7;
+  box-shadow: 0 12px 30px rgba(168, 85, 247, 0.45);
 }
 
 .lobby-card--compact {


### PR DESCRIPTION
## Summary
- fall back to sample lobby previews when the lobby fetch fails
- let mock lobby cards and join-by-id navigation open the lobby UI without a backend
- keep the join button active with the bright-purple hover state even in preview mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d64eb24d44832586b82a0c2adbacd5