### PR TITLE
Improve dev seeding resilience and data coverage

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,11 @@ LOG_LEVEL=debug
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001,http://localhost:8080,http://localhost:5173
 
 # Redis
-REDIS_ALLOW_MOCK_FALLBACK=false
+REDIS_ALLOW_MOCK_FALLBACK=true
+
+# Database fallbacks
+DB_ALLOW_IN_MEMORY_FALLBACK=true
+MONGODB_MEMORY_DB_NAME=maoga_dev_memory
 
 # IGDB API Configuration
 IGDB_CLIENT_ID=igdb-client-id

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -20,10 +20,11 @@ This document explains how to run the Maoga stack (backend + frontend) locally w
 When `npm run dev` is running, the API listens on `http://localhost:3000` and the frontend on `http://localhost:5173`. Update `frontend/.env` if you need to target a different API origin.
 
 ## Preloaded development data
-- `npm run dev` seeds the local Mongo database with sample games, six user accounts, active lobbies, and active matchmaking searches once the backend connects.
-- Seeded accounts (password `PlayTogether123!`): `brimstone@maoga.test`, `aurora@maoga.test`, `viper@maoga.test`, `pixelwave@maoga.test`, `supportive@maoga.test`, `shotcaller@maoga.test`.
+- `npm run dev` seeds the local database with sample games, six user accounts, active lobbies, matchmaking searches, rich friendship graphs, notification inbox entries, and seeded chat conversations once the backend connects.
+- Seeded accounts (password `PlayTogether123!`): `brimstone@maoga.dev`, `aurora@maoga.dev`, `viper@maoga.dev`, `pixelwave@maoga.dev`, `supportive@maoga.dev`, `shotcaller@maoga.dev`.
 - Control the behaviour with environment flags: `SKIP_DEV_SEED=true` skips seeding, `ENABLE_DEV_SEED=true` forces it outside development, `FAIL_ON_DEV_SEED_ERROR=true` makes startup fail if the seeding script throws.
-- Example lobbies created on boot: `Valorant Night Ranked`, `Summoner's Rift Flex Squad`, and `Fortnite Zero Build Friday`.
+- Example lobbies created on boot: `Valorant Night Ranked`, `Summoner's Rift Flex Squad`, and `Fortnite Zero Build Friday`. Each lobby also links to a seeded chat thread so you can view real-time conversation flows immediately.
+- When local infrastructure is unavailable the backend automatically falls back to in-memory services: set `REDIS_ALLOW_MOCK_FALLBACK=true` to enable the Redis mock (default in `.env`) and `DB_ALLOW_IN_MEMORY_FALLBACK=true` to allow a temporary MongoDB instance via `mongodb-memory-server`.
 
 ## Tests and linting
 - `npm test` executes the backend test suite (Mocha + SuperTest) with the proper environment flags.

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -4,6 +4,30 @@ const baseLogger = require('../utils/logger');
 
 const logger = baseLogger.forModule('database:connection');
 const mongooseLogger = baseLogger.forModule('database:mongoose');
+const memoryLogger = baseLogger.forModule('database:memory');
+
+const FALLBACK_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'EHOSTUNREACH'
+]);
+
+const FALLBACK_ERROR_MESSAGE_FRAGMENTS = [
+  'failed to connect',
+  'server selection timed out',
+  'connection refused',
+  'connect econnrefused',
+  'getaddrinfo',
+  'unreachable',
+  'timed out',
+  'closed before handshake'
+];
+
+let MongoMemoryServer;
 
 function configureDebugLogging() {
   if (config.database?.debug) {
@@ -46,50 +70,37 @@ class DatabaseManager {
   constructor() {
     this.isConnected = false;
     this.connectionPromise = null;
+    this.memoryServer = null;
+    this.memoryUri = null;
+    this.isUsingMemory = false;
+    this.listenersAttached = false;
   }
 
   async connect() {
-    if (this.connectionPromise) {
-      return this.connectionPromise;
+    if (!this.connectionPromise) {
+      this.connectionPromise = this._connect().catch((error) => {
+        this.connectionPromise = null;
+        throw error;
+      });
     }
-    this.connectionPromise = await this._connect();
-    return this.connectionPromise;
+
+    return await this.connectionPromise;
   }
 
   async _connect() {
     const uri = process.env.MONGODB_TEST_URI || config.database.uri;
+
+    logger.info('Attempting MongoDB connection', {
+      uri,
+      options: config.database.options,
+      inMemoryFallback: this._isMemoryFallbackEnabled()
+    });
+
     try {
-      logger.info('Attempting MongoDB connection', {
-        uri,
-        options: config.database.options
-      });
-
-      await mongoose.connect(uri, config.database.options);
-      this.isConnected = true;
-
-      logger.info('MongoDB connected successfully', {
-        host: mongoose.connection.host,
-        port: mongoose.connection.port,
-        database: mongoose.connection.name
-      });
-
-      mongoose.connection.on('error', (error) => {
-        mongooseLogger.error('MongoDB connection error', { error: error.message });
-      });
-
-      mongoose.connection.on('disconnected', () => {
-        this.isConnected = false;
-        mongooseLogger.warn('MongoDB disconnected');
-      });
-
-      mongoose.connection.on('reconnected', () => {
-        this.isConnected = true;
-        mongooseLogger.info('MongoDB reconnected');
-      });
-
-      return mongoose.connection;
+      return await this._connectWithUri(uri, { isMemory: false });
     } catch (error) {
       this.isConnected = false;
+
       mongooseLogger.error('Failed to connect to MongoDB', {
         errorMessage: error.message,
         errorStack: error.stack,
@@ -97,8 +108,101 @@ class DatabaseManager {
         errorName: error.name,
         uri
       });
+
+      const fallbackConnection = await this._attemptMemoryFallback(error);
+      if (fallbackConnection) {
+        return fallbackConnection;
+      }
+
       throw error;
     }
+  }
+
+  async _connectWithUri(uri, { isMemory }) {
+    await mongoose.connect(uri, config.database.options);
+
+    this.isConnected = true;
+    this.isUsingMemory = Boolean(isMemory);
+    this.memoryUri = isMemory ? uri : null;
+    this._attachConnectionEventListeners();
+
+    const connection = mongoose.connection;
+    logger.info('MongoDB connected successfully', {
+      host: connection.host,
+      port: connection.port,
+      database: connection.name,
+      storage: this.isUsingMemory ? 'in-memory' : 'external'
+    });
+
+    return connection;
+  }
+
+  async _attemptMemoryFallback(error) {
+    if (!this._shouldFallbackToMemory(error)) {
+      return null;
+    }
+
+    if (!MongoMemoryServer) {
+      ({ MongoMemoryServer } = require('mongodb-memory-server'));
+    }
+
+    if (!this.memoryServer) {
+      const dbName = config.database?.memory?.dbName;
+      const memoryOptions = dbName ? { instance: { dbName } } : undefined;
+      this.memoryServer = await MongoMemoryServer.create(memoryOptions);
+      this.memoryUri = this.memoryServer.getUri(dbName);
+    }
+
+    memoryLogger.warn('Falling back to in-memory MongoDB instance for development use', {
+      reason: error.message,
+      uri: this.memoryUri
+    });
+
+    return await this._connectWithUri(this.memoryUri, { isMemory: true });
+  }
+
+  _attachConnectionEventListeners() {
+    if (this.listenersAttached) {
+      return;
+    }
+
+    mongoose.connection.on('error', (error) => {
+      mongooseLogger.error('MongoDB connection error', { error: error.message });
+    });
+
+    mongoose.connection.on('disconnected', () => {
+      this.isConnected = false;
+      mongooseLogger.warn('MongoDB disconnected');
+    });
+
+    mongoose.connection.on('reconnected', () => {
+      this.isConnected = true;
+      mongooseLogger.info('MongoDB reconnected');
+    });
+
+    this.listenersAttached = true;
+  }
+
+  _isMemoryFallbackEnabled() {
+    return Boolean(config.database?.allowInMemoryFallback);
+  }
+
+  _shouldFallbackToMemory(error) {
+    if (!this._isMemoryFallbackEnabled()) {
+      return false;
+    }
+
+    if (!error) {
+      return false;
+    }
+
+    const code = error.code || error.errno;
+    if (code && FALLBACK_ERROR_CODES.has(code)) {
+      return true;
+    }
+
+    const message = (error.message || '').toLowerCase();
+    return FALLBACK_ERROR_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
   }
 
   async disconnect() {
@@ -107,6 +211,16 @@ class DatabaseManager {
       this.isConnected = false;
       logger.info('MongoDB disconnected gracefully');
     }
+
+    if (this.memoryServer) {
+      await this.memoryServer.stop();
+      memoryLogger.info('In-memory MongoDB instance stopped');
+      this.memoryServer = null;
+      this.memoryUri = null;
+      this.isUsingMemory = false;
+    }
+
+    this.connectionPromise = null;
   }
 
   getConnection() {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -66,6 +66,13 @@ const baseConfig = {
   },
   database: {
     debug: parseBoolean(process.env.MONGOOSE_DEBUG, env === 'development'),
+    allowInMemoryFallback: parseBoolean(
+      process.env.DB_ALLOW_IN_MEMORY_FALLBACK,
+      env !== 'production'
+    ),
+    memory: {
+      dbName: process.env.MONGODB_MEMORY_DB_NAME || 'maoga_dev_memory'
+    },
     // Default options that can be overridden by environment-specific files
     options: {
       serverSelectionTimeoutMS: 5000,
@@ -181,7 +188,13 @@ const mergedConfig = {
         ? 'mongodb://localhost:27017/maoga_dev'
         : 'mongodb://localhost:27017/maoga_prod_default'), // Default for prod if not set
     options: { ...baseConfig.database.options, ...envConfig.database?.options },
-    debug: envConfig.database?.debug ?? baseConfig.database.debug
+    debug: envConfig.database?.debug ?? baseConfig.database.debug,
+    allowInMemoryFallback:
+      envConfig.database?.allowInMemoryFallback ?? baseConfig.database.allowInMemoryFallback,
+    memory: {
+      ...baseConfig.database.memory,
+      ...envConfig.database?.memory
+    }
   }
 };
 

--- a/src/utils/devSeeder.js
+++ b/src/utils/devSeeder.js
@@ -1309,7 +1309,10 @@ function buildNotificationData(seed, userMap, lobbyMap) {
   const data = {};
 
   if (seed.data?.entityType === 'user') {
-    const targetUser = ensureUser(userMap, seed.data.username || seed.data.user || seed.data.targetUsername);
+    const targetUser = ensureUser(
+      userMap,
+      seed.data.username || seed.data.user || seed.data.targetUsername
+    );
     data.entityType = 'user';
     data.entityId = targetUser._id;
   } else if (seed.data?.entityType === 'lobby' || seed.lobbyName) {

--- a/src/utils/devSeeder.js
+++ b/src/utils/devSeeder.js
@@ -4,6 +4,9 @@ const User = require('../modules/auth/models/User');
 const Game = require('../modules/game/models/Game');
 const Lobby = require('../modules/lobby/models/Lobby');
 const MatchRequest = require('../modules/matchmaking/models/MatchRequest');
+const Friendship = require('../modules/social/models/Friendship');
+const Notification = require('../modules/notification/models/Notification');
+const Chat = require('../modules/chat/models/Chat');
 
 const logger = baseLogger.forModule('dev:seeder');
 
@@ -235,7 +238,7 @@ const GAME_SEEDS = [
 
 const USER_SEEDS = [
   {
-    email: 'brimstone@maoga.test',
+    email: 'brimstone@maoga.dev',
     username: 'brimstone',
     password: 'PlayTogether123!',
     role: 'user',
@@ -287,7 +290,7 @@ const USER_SEEDS = [
     lastActive: minutesAgo(6)
   },
   {
-    email: 'aurora@maoga.test',
+    email: 'aurora@maoga.dev',
     username: 'aurora',
     password: 'PlayTogether123!',
     role: 'user',
@@ -338,7 +341,7 @@ const USER_SEEDS = [
     lastActive: minutesAgo(12)
   },
   {
-    email: 'viper@maoga.test',
+    email: 'viper@maoga.dev',
     username: 'viper',
     password: 'PlayTogether123!',
     role: 'user',
@@ -389,7 +392,7 @@ const USER_SEEDS = [
     lastActive: minutesAgo(4)
   },
   {
-    email: 'pixelwave@maoga.test',
+    email: 'pixelwave@maoga.dev',
     username: 'pixelwave',
     password: 'PlayTogether123!',
     role: 'user',
@@ -440,7 +443,7 @@ const USER_SEEDS = [
     lastActive: minutesAgo(9)
   },
   {
-    email: 'supportive@maoga.test',
+    email: 'supportive@maoga.dev',
     username: 'supportive',
     password: 'PlayTogether123!',
     role: 'user',
@@ -490,7 +493,7 @@ const USER_SEEDS = [
     lastActive: minutesAgo(14)
   },
   {
-    email: 'shotcaller@maoga.test',
+    email: 'shotcaller@maoga.dev',
     username: 'shotcaller',
     password: 'PlayTogether123!',
     role: 'user',
@@ -764,6 +767,183 @@ const MATCH_REQUEST_SEEDS = [
   }
 ];
 
+const FRIENDSHIP_SEEDS = [
+  {
+    users: ['brimstone', 'viper'],
+    status: 'accepted',
+    requestedBy: 'viper',
+    acceptedMinutesAgo: 180
+  },
+  {
+    users: ['pixelwave', 'supportive'],
+    status: 'accepted',
+    requestedBy: 'supportive',
+    acceptedMinutesAgo: 260
+  },
+  {
+    users: ['aurora', 'supportive'],
+    status: 'pending',
+    requestedBy: 'supportive',
+    createdMinutesAgo: 45
+  },
+  {
+    users: ['shotcaller', 'viper'],
+    status: 'accepted',
+    requestedBy: 'shotcaller',
+    acceptedMinutesAgo: 90
+  },
+  {
+    users: ['brimstone', 'aurora'],
+    status: 'declined',
+    requestedBy: 'aurora',
+    declinedMinutesAgo: 25
+  }
+];
+
+const NOTIFICATION_SEEDS = [
+  {
+    username: 'brimstone',
+    type: 'friend_request',
+    title: 'Aurora sent you a friend request',
+    message: "Aurora would like to coordinate for tonight's ranked session.",
+    status: 'unread',
+    createdMinutesAgo: 12,
+    deliveryChannels: ['inApp', 'push'],
+    data: {
+      entityType: 'user',
+      username: 'aurora',
+      metadata: {
+        mutualGames: 2,
+        lastPlayedMinutesAgo: 90
+      }
+    }
+  },
+  {
+    username: 'supportive',
+    type: 'lobby_invite',
+    title: 'Lobby invite: Valorant Night Ranked',
+    message: 'Brimstone invited you to join the Valorant Night Ranked lobby.',
+    status: 'unread',
+    createdMinutesAgo: 28,
+    deliveryChannels: ['inApp'],
+    lobbyName: 'Valorant Night Ranked',
+    data: {
+      entityType: 'lobby'
+    }
+  },
+  {
+    username: 'pixelwave',
+    type: 'lobby_ready',
+    title: 'Your Valorant lobby is ready',
+    message: 'All players marked ready in Valorant Night Ranked.',
+    status: 'read',
+    createdMinutesAgo: 35,
+    readMinutesAgo: 30,
+    priority: 'high',
+    lobbyName: 'Valorant Night Ranked',
+    deliveryChannels: ['inApp', 'push']
+  },
+  {
+    username: 'aurora',
+    type: 'friend_accepted',
+    title: 'Supportive accepted your friend request',
+    message: 'You can now share schedules and queue together.',
+    status: 'unread',
+    createdMinutesAgo: 18,
+    deliveryChannels: ['inApp', 'email'],
+    data: {
+      entityType: 'user',
+      username: 'supportive'
+    }
+  },
+  {
+    username: 'shotcaller',
+    type: 'system_announcement',
+    title: 'Ranked matchmaking maintenance',
+    message: 'Ranked queues will pause for 30 minutes at 23:00 in your region.',
+    status: 'unread',
+    createdMinutesAgo: 55,
+    expiresMinutesFromNow: 240,
+    deliveryChannels: ['inApp'],
+    priority: 'medium'
+  }
+];
+
+const CHAT_SEEDS = [
+  {
+    chatType: 'lobby',
+    lobbyName: 'Valorant Night Ranked',
+    participants: ['brimstone', 'viper', 'pixelwave', 'supportive'],
+    messages: [
+      {
+        sender: 'brimstone',
+        content: "Thanks for hopping in tonight—let's warm up with a couple of rounds.",
+        minutesAgo: 18
+      },
+      {
+        sender: 'supportive',
+        content: 'Invited Aurora as backup if we need a flex support.',
+        minutesAgo: 17
+      },
+      {
+        content: 'PixelWave joined the lobby.',
+        contentType: 'system',
+        minutesAgo: 16
+      },
+      {
+        sender: 'pixelwave',
+        content: 'Ready to lock support—calls and heals on point.',
+        minutesAgo: 15
+      },
+      {
+        sender: 'viper',
+        content: "Queueing up now. Let's dominate.",
+        minutesAgo: 14
+      }
+    ]
+  },
+  {
+    chatType: 'direct',
+    participants: ['aurora', 'supportive'],
+    messages: [
+      {
+        sender: 'supportive',
+        content: 'Want to duo after scrims tonight?',
+        minutesAgo: 42
+      },
+      {
+        sender: 'aurora',
+        content: 'Yes! I can be on around 21:00 CET.',
+        minutesAgo: 40
+      }
+    ]
+  },
+  {
+    chatType: 'group',
+    participants: ['brimstone', 'shotcaller', 'viper'],
+    metadata: {
+      name: 'Scrim Planning'
+    },
+    messages: [
+      {
+        sender: 'shotcaller',
+        content: 'Scrim tomorrow at 20:00? Need confirmations.',
+        minutesAgo: 120
+      },
+      {
+        sender: 'brimstone',
+        content: "Works for me. Let's review the split push VOD beforehand.",
+        minutesAgo: 118
+      },
+      {
+        sender: 'viper',
+        content: "I'm in. I'll bring updated executes for Icebox.",
+        minutesAgo: 116
+      }
+    ]
+  }
+];
+
 function shouldRunSeeder() {
   if (process.env.SKIP_DEV_SEED === 'true') {
     logger.info('Skipping dev data seed because SKIP_DEV_SEED flag is set');
@@ -794,6 +974,14 @@ function ensureUser(userMap, username) {
     throw new Error(`Missing seeded user for username "${username}"`);
   }
   return user;
+}
+
+function ensureLobby(lobbyMap, lobbyName) {
+  const lobby = lobbyMap.get(lobbyName);
+  if (!lobby) {
+    throw new Error(`Missing seeded lobby for name "${lobbyName}"`);
+  }
+  return lobby;
 }
 
 async function seedGames() {
@@ -1046,6 +1234,261 @@ async function seedMatchRequests(userMap, gameMap, lobbyMap) {
   logger.info('Seeded dev match requests', { count: matchRequests.length });
 }
 
+async function seedFriendships(userMap) {
+  let count = 0;
+
+  for (const seed of FRIENDSHIP_SEEDS) {
+    const [userA, userB] = seed.users.map((username) => ensureUser(userMap, username));
+    const requestedBy = ensureUser(userMap, seed.requestedBy);
+
+    let friendship = await Friendship.findOne({
+      $or: [
+        { user1Id: userA._id, user2Id: userB._id },
+        { user1Id: userB._id, user2Id: userA._id }
+      ]
+    });
+
+    if (!friendship) {
+      friendship = new Friendship({
+        user1Id: userA._id,
+        user2Id: userB._id,
+        status: seed.status,
+        requestedBy: requestedBy._id
+      });
+    } else {
+      friendship.set({
+        user1Id: userA._id,
+        user2Id: userB._id,
+        status: seed.status,
+        requestedBy: requestedBy._id
+      });
+    }
+
+    if (seed.blockedBy) {
+      friendship.blockedBy = ensureUser(userMap, seed.blockedBy)._id;
+    } else {
+      friendship.blockedBy = undefined;
+    }
+
+    if (typeof seed.acceptedMinutesAgo === 'number') {
+      friendship.acceptedAt = minutesAgo(seed.acceptedMinutesAgo);
+    } else if (seed.acceptedAt) {
+      friendship.acceptedAt = seed.acceptedAt;
+    } else if (friendship.status !== 'accepted') {
+      friendship.acceptedAt = undefined;
+    }
+
+    if (typeof seed.declinedMinutesAgo === 'number') {
+      friendship.declinedAt = minutesAgo(seed.declinedMinutesAgo);
+    } else if (seed.declinedAt) {
+      friendship.declinedAt = seed.declinedAt;
+    } else if (friendship.status !== 'declined') {
+      friendship.declinedAt = undefined;
+    }
+
+    if (typeof seed.blockedMinutesAgo === 'number') {
+      friendship.blockedAt = minutesAgo(seed.blockedMinutesAgo);
+    } else if (seed.blockedAt) {
+      friendship.blockedAt = seed.blockedAt;
+    } else if (friendship.status !== 'blocked') {
+      friendship.blockedAt = undefined;
+    }
+
+    await friendship.save();
+    count += 1;
+  }
+
+  logger.info('Seeded dev friendships', { count });
+}
+
+function buildNotificationData(seed, userMap, lobbyMap) {
+  if (!seed.data && !seed.lobbyName) {
+    return undefined;
+  }
+
+  const data = {};
+
+  if (seed.data?.entityType === 'user') {
+    const targetUser = ensureUser(userMap, seed.data.username || seed.data.user || seed.data.targetUsername);
+    data.entityType = 'user';
+    data.entityId = targetUser._id;
+  } else if (seed.data?.entityType === 'lobby' || seed.lobbyName) {
+    const lobbyName = seed.lobbyName || seed.data?.lobbyName;
+    const lobby = ensureLobby(lobbyMap, lobbyName);
+    data.entityType = 'lobby';
+    data.entityId = lobby._id;
+  } else if (seed.data?.entityType) {
+    data.entityType = seed.data.entityType;
+    if (seed.data.entityId) {
+      data.entityId = seed.data.entityId;
+    }
+  }
+
+  if (seed.data?.actionUrl) {
+    data.actionUrl = seed.data.actionUrl;
+  }
+
+  if (seed.data?.metadata) {
+    data.metadata = new Map(Object.entries(seed.data.metadata));
+  }
+
+  return Object.keys(data).length > 0 ? data : undefined;
+}
+
+async function seedNotifications(userMap, lobbyMap) {
+  let count = 0;
+
+  for (const seed of NOTIFICATION_SEEDS) {
+    const user = ensureUser(userMap, seed.username);
+    const data = buildNotificationData(seed, userMap, lobbyMap);
+
+    let notification = await Notification.findOne({
+      userId: user._id,
+      type: seed.type,
+      title: seed.title
+    });
+
+    const payload = {
+      userId: user._id,
+      type: seed.type,
+      title: seed.title,
+      message: seed.message,
+      status: seed.status || 'unread',
+      priority: seed.priority || 'medium'
+    };
+
+    if (!notification) {
+      notification = new Notification(payload);
+    } else {
+      notification.set(payload);
+    }
+
+    const deliveryChannels = seed.deliveryChannels?.length ? seed.deliveryChannels : ['inApp'];
+    notification.set('deliveryChannels', deliveryChannels);
+
+    if (data) {
+      notification.set('data', data);
+    } else {
+      notification.set('data', undefined);
+    }
+    notification.markModified('data');
+
+    if (typeof seed.readMinutesAgo === 'number') {
+      notification.status = 'read';
+      notification.readAt = minutesAgo(seed.readMinutesAgo);
+    } else if (notification.status === 'read' && !notification.readAt) {
+      notification.readAt = new Date();
+    } else if (notification.status !== 'read') {
+      notification.readAt = undefined;
+    }
+
+    if (typeof seed.expiresMinutesFromNow === 'number') {
+      notification.expiresAt = minutesFromNow(seed.expiresMinutesFromNow);
+    } else if (typeof seed.expiresMinutesAgo === 'number') {
+      notification.expiresAt = minutesAgo(seed.expiresMinutesAgo);
+    } else {
+      notification.expiresAt = undefined;
+    }
+
+    await notification.save();
+    count += 1;
+  }
+
+  logger.info('Seeded dev notifications', { count });
+}
+
+async function seedChats(userMap, lobbyMap) {
+  const chats = [];
+
+  for (const seed of CHAT_SEEDS) {
+    const participantDocs = seed.participants.map((username) => ensureUser(userMap, username));
+    const participantIds = participantDocs
+      .map((doc) => doc._id)
+      .sort((a, b) => a.toString().localeCompare(b.toString()));
+
+    let chat;
+    let lobby;
+
+    if (seed.chatType === 'lobby') {
+      lobby = ensureLobby(lobbyMap, seed.lobbyName);
+      chat = await Chat.findOne({ chatType: 'lobby', lobbyId: lobby._id });
+      if (!chat) {
+        chat = new Chat({ chatType: 'lobby', lobbyId: lobby._id, participants: participantIds });
+      } else {
+        chat.set({ chatType: 'lobby', lobbyId: lobby._id, participants: participantIds });
+      }
+    } else {
+      chat = await Chat.findOne({
+        chatType: seed.chatType,
+        participants: { $all: participantIds }
+      });
+
+      if (chat && chat.participants.length !== participantIds.length) {
+        chat = null;
+      }
+
+      if (!chat) {
+        chat = new Chat({ chatType: seed.chatType, participants: participantIds });
+      } else {
+        chat.set({ chatType: seed.chatType, participants: participantIds, lobbyId: undefined });
+      }
+    }
+
+    if (seed.metadata) {
+      chat.metadata = new Map(Object.entries(seed.metadata));
+      chat.markModified('metadata');
+    } else if (chat.metadata && chat.metadata.size > 0) {
+      chat.metadata = undefined;
+      chat.markModified('metadata');
+    }
+
+    const messages = seed.messages.map((message) => {
+      const createdAt =
+        typeof message.minutesAgo === 'number'
+          ? minutesAgo(message.minutesAgo)
+          : message.createdAt || new Date();
+
+      const contentType = message.contentType || 'text';
+      const payload = {
+        content: message.content,
+        contentType,
+        createdAt
+      };
+
+      if (message.metadata) {
+        payload.metadata = new Map(Object.entries(message.metadata));
+      }
+
+      if (contentType !== 'system' && contentType !== 'auto') {
+        if (!message.sender) {
+          throw new Error('Chat seed missing sender for non-system message');
+        }
+        const senderDoc = ensureUser(userMap, message.sender);
+        payload.senderId = senderDoc._id;
+      }
+
+      return payload;
+    });
+
+    chat.set('messages', messages);
+    chat.markModified('messages');
+    chat.lastMessageAt = messages.length ? messages[messages.length - 1].createdAt : undefined;
+
+    await chat.save();
+    chats.push(chat);
+
+    if (seed.chatType === 'lobby' && lobby) {
+      if (!lobby.chatId || lobby.chatId.toString() !== chat._id.toString()) {
+        lobby.chatId = chat._id;
+        await lobby.save();
+        lobbyMap.set(seed.lobbyName, lobby);
+      }
+    }
+  }
+
+  logger.info('Seeded dev chats', { count: chats.length });
+}
+
 async function seedDevData() {
   if (hasSeeded) {
     return;
@@ -1062,6 +1505,9 @@ async function seedDevData() {
     const users = await seedUsers(games);
     const lobbies = await seedLobbies(users, games);
     await seedMatchRequests(users, games, lobbies);
+    await seedFriendships(users);
+    await seedNotifications(users, lobbies);
+    await seedChats(users, lobbies);
     logger.info('Baseline development data ready');
   } catch (error) {
     logger.error('Dev data seeding failed', { error: error.message, stack: error.stack });


### PR DESCRIPTION
## Summary
- enable optional in-memory MongoDB fallback and turn on Redis mock fallback for local development
- expand the development seeding script with richer user relationships, notifications, chat histories, and updated sample emails
- document the new defaults and seeded data so local testing reflects live data scenarios

## Testing
- npm run lint:backend
- FAIL_ON_DEV_SEED_ERROR=true node -e "(async () => { const db = require('./src/config/database'); const { seedDevData } = require('./src/utils/devSeeder'); try { await db.connect(); await seedDevData(); } finally { await db.disconnect(); process.exit(0); } })();"

------
https://chatgpt.com/codex/tasks/task_e_68d66606012883258a58a431c0679d55